### PR TITLE
disabled sign in button if input fields are empty

### DIFF
--- a/src/components/pages/login/Login.js
+++ b/src/components/pages/login/Login.js
@@ -4,17 +4,36 @@ import axios from '../../../api/axios';
 import { Link } from 'react-router-dom';
 import { Form } from 'react-bootstrap';
 
+import Info from '../../../assets/icons/Info';
+const EMAIL_REGEX = /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/;
+const PWD_REGEX = /.{6,16}$/;
+
+
+
 const Login = () => {
     const emailRef = useRef();
     const errorRef = useRef();
 
     const [email, setEmail] = useState('');
+    const [validEmail, setValidEmail] = useState(false);
+    const [emailFocus, setEmailFocus] = useState(false);
+
     const [password, setPassword] = useState('');
+    const [validPwd, setValidPwd] = useState(false);
+    const [pwdFocus, setPwdFocus] = useState(false);
     const [errorMsg, setErrorMsg] = useState('');
 
     useEffect(() => {
         emailRef.current.focus();
     }, [])
+
+    useEffect(() => {
+        setValidEmail(EMAIL_REGEX.test(email));
+    }, [email])
+
+    useEffect(() => {
+        setValidPwd(PWD_REGEX.test(password));
+    }, [password])
 
     useEffect(() => {
         setErrorMsg('');
@@ -59,7 +78,28 @@ const Login = () => {
                                     onChange={(e) => setEmail(e.target.value)}
                                     value={email}
                                     required
+                                    aria-invalid={validEmail ? "false" : "true"}
+                                    aria-describedby="emailnote"
+                                    onFocus={() => setEmailFocus(true)}
+                                    onBlur={() => setEmailFocus(false)}
                                 />
+                                <p
+                                    id="emailnote"
+                                    className={
+                                        emailFocus && email && !validEmail
+                                            ? "instructions"
+                                            : "offscreen"
+                                    }
+                                    >
+                                    <div className='valid-icons'>
+                                        <Info />
+                                        <ul className='w-100'>
+                                            <li>
+                                                Please enter a valid e-mail format.
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </p>
                             </Form.Group>
                             <Form.Group >
                                 <Form.Label htmlFor="password">password:</Form.Label>
@@ -69,10 +109,44 @@ const Login = () => {
                                     id="password"
                                     onChange={(e) => setPassword(e.target.value)}
                                     value={password}
+                                    minlength="6"
+                                    maxlength="16"
                                     required
+                                    aria-invalid={validPwd ? "false" : "true"}
+                                    aria-describedby="pwdnote"
+                                    onFocus={() => setPwdFocus(true)}
+                                    onBlur={() => setPwdFocus(false)}
                                 />
+                                <p
+                                    id="pwdnote"
+                                    className={
+                                        pwdFocus && password && !validPwd
+                                            ? "instructions"
+                                            : "offscreen"
+                                    }
+                                    >
+                                    <div className='valid-icons'>
+                                        <Info />
+                                        <ul className='w-100'>
+                                            <li>
+                                                6 to 16 characters.
+                                            </li>
+                                        </ul>
+                                    </div>
+                                </p>
                             </Form.Group>
-                            <button className='btn-custom my-4' type='submit'>
+                            <button 
+                                className={
+                                    !validEmail  || !validPwd
+                                        ? 'btn-custom-disabled my-4'
+                                        : 'btn-custom my-4'
+                                }
+                                disabled={
+                                    !validEmail || !validPwd
+                                        ? true
+                                        : false
+                                }
+                            >
                                 <span className='btn-custom_top'> sign in
                                 </span>
                             </button>


### PR DESCRIPTION
Disabled sign in button if input fields are empty and don't fill requirements, min and max input characters added.
Info display with instructions added.
Screen reader compatible.

ticket link: 
https://trello.com/c/ChHUs0OX/26-disable-sign-in-button-if-all-in-login-page
