### PR TITLE
background in carousel indicators fixed

### DIFF
--- a/src/components/pages/home/carousel.css
+++ b/src/components/pages/home/carousel.css
@@ -4,7 +4,6 @@
 }
 
 .carousel-indicators{
-  background-image: url(../../../assets/img/papelTexture.webp);
   position: absolute;
   bottom: -1rem !important;
   height: 3rem;


### PR DESCRIPTION
ticket link: https://trello.com/c/z7T6vHF2/52-remove-rectangle-from-carousel-in-home-page